### PR TITLE
Texture choice

### DIFF
--- a/examples/example1.cpp
+++ b/examples/example1.cpp
@@ -150,7 +150,7 @@ void main() {
         {
             grid
                 .ListItem(&selected, i)
-                .Image("lollipop");
+                .Image(TexGui::texByName("lollipop"));
         }
 
         TexGui::render();

--- a/include/types.h
+++ b/include/types.h
@@ -86,17 +86,21 @@ struct CharInfo
 
 struct TexEntry
 {
+    unsigned int glID;
     int layer;
 
+    Math::ibox bounds;
+    
+    // Flags for if the texture has alternate images for states e.g. hovered/pressed etc
     unsigned int has_state = 0;
 
+    // Used for 9-slice rendering
     float top;
     float right;
     float bottom;
     float left;
 
-    Math::ibox bounds;
-
+    // #TODO: low priority - this shouldn't be in the struct, and just in a temporary map when creating our atlas
     unsigned char* data;
     unsigned char* _hover;
     unsigned char* _press;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -239,6 +239,8 @@ void GLContext::renderFromRD(const RenderData& data) {
         {
             case Command::QUAD:
             {
+                glBindTextureUnit(m_ta.texture.bind, c.texentry->glID);
+                
                 if (c.flags & SLICE_9)
                 {
                     m_shaders.quad9slice.use();
@@ -381,6 +383,10 @@ void GLContext::loadTextures(const char* dir)
         files.push_back(f);
     }
 
+    GLuint texID = -1;
+    glCreateTextures(GL_TEXTURE_2D_ARRAY, 1, &texID);
+    m_ta.texture.buf = texID;
+
 
     for (auto& f : files)
     {
@@ -418,13 +424,15 @@ void GLContext::loadTextures(const char* dir)
         }
         else
         {
-            m_tex_map[fstr].bounds.w = width; 
-            m_tex_map[fstr].bounds.h = height; 
-            
-            m_tex_map[fstr].top = height/3.f;
-            m_tex_map[fstr].right = width/3.f;
-            m_tex_map[fstr].bottom = height/3.f;
-            m_tex_map[fstr].left = width/3.f;
+            TexEntry& t = m_tex_map[fstr];
+            t.bounds.w = width; 
+            t.bounds.h = height; 
+
+            t.top = height/3.f;
+            t.right = width/3.f;
+            t.bottom = height/3.f;
+            t.left = width/3.f;
+            t.glID = texID;
         }
 
         if (pstr.ends_with(".hover.png"))
@@ -510,7 +518,6 @@ void GLContext::loadTextures(const char* dir)
                 memcpy(active + 4 * tc(rect.x, rect.y + row), e._active + (4 * e.bounds.w * row), e.bounds.w * 4);
     }
 
-    glCreateTextures(GL_TEXTURE_2D_ARRAY, 1, &m_ta.texture.buf);
     glTextureStorage3D(m_ta.texture.buf, 1, GL_RGBA8, ATLAS_SIZE, ATLAS_SIZE, 4);
 
     glTextureSubImage3D(m_ta.texture.buf, 0, 0, 0, 0, ATLAS_SIZE, ATLAS_SIZE, 1, GL_RGBA, GL_UNSIGNED_BYTE, atlas);

--- a/src/texgui.cpp
+++ b/src/texgui.cpp
@@ -202,6 +202,24 @@ void TexGui::loadTextures(const char* dir)
     GTexGui->renderCtx.loadTextures(dir);
 }
 
+extern std::unordered_map<std::string, TexGui::TexEntry> m_tex_map;
+
+// We just need pointer stability, we aren't gonna be iterating it so using list :P
+// This is a heap alloc per entry which is a bit of a pain so should change since we barely use heap at all otherwise #TODO
+static std::list<TexEntry> m_custom_texs;
+
+
+TexEntry* TexGui::texByName(const char* name)
+{
+    assert(m_tex_map.contains(name));
+    return &m_tex_map[name];
+}
+
+TexEntry* customTexture(unsigned int glTexID, unsigned int layer, Math::ibox pixelBounds)
+{
+    return &m_custom_texs.emplace_back(glTexID, layer, pixelBounds);
+}
+
 struct InputFrame
 {
     Math::fvec2 cursorPos;

--- a/texgui.h
+++ b/texgui.h
@@ -434,7 +434,7 @@ public:
     RenderData* rs;
     Math::fbox bounds;
 
-    Container Window(const char* name, float xpos, float ypos, float width, float height, uint32_t flags = 0);
+    Container Window(const char* name, float xpos, float ypos, float width, float height, uint32_t flags = 0,  TexEntry* texture = nullptr);
     bool      Button(const char* text, TexEntry* texture = nullptr);
     Container Box(float xpos, float ypos, float width, float height, TexEntry* texture = nullptr);
     void      TextInput(const char* name, std::string& buf);

--- a/texgui.h
+++ b/texgui.h
@@ -507,6 +507,13 @@ void loadFont(const char* font);
 void loadTextures(const char* dir);
 void clear();
 
+struct TexEntry;
+
+// Get a specific texture that was read by loadTextures
+TexEntry* texByName(const char* name);
+// Prepare a reference to a texture already present in an OpenGL array texture.
+TexEntry* customTexture(unsigned int glTexID, unsigned int layer, Math::ibox pixelBounds);
+
 NAMESPACE_BEGIN(Defaults);
 
 inline int PixelSize  = 1;

--- a/texgui.h
+++ b/texgui.h
@@ -422,6 +422,8 @@ NAMESPACE_END(Math);
 struct RenderData;
 bool initGlfwOpenGL(GLFWwindow* window);
 
+struct TexEntry;
+
 class Container
 {
     friend struct Arrangers;
@@ -433,10 +435,10 @@ public:
     Math::fbox bounds;
 
     Container Window(const char* name, float xpos, float ypos, float width, float height, uint32_t flags = 0);
-    bool      Button(const char* text, const char* texture = nullptr);
-    Container Box(float xpos, float ypos, float width, float height, const char* texture = nullptr);
+    bool      Button(const char* text, TexEntry* texture = nullptr);
+    Container Box(float xpos, float ypos, float width, float height, TexEntry* texture = nullptr);
     void      TextInput(const char* name, std::string& buf);
-    void      Image(const char* text);
+    void      Image(TexEntry* texture);
 
     // Similar to radio buttons - the id of the selected one is stored in the *selected pointer.
     Container ListItem(uint32_t* selected, uint32_t id);


### PR DESCRIPTION
API now uses TexEntry* for textures instead of string. Added api methods to cache lookup of texture by name, or to add an existing opengl texture