### PR TITLE
New widgets

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -115,8 +115,11 @@ float TexGui::computeTextWidth(const char* text, size_t numchars)
     return total;
 }
 
-int RenderData::drawText(const char* text, Math::fvec2 pos, const Math::fvec4& col, int size, uint32_t flags, int32_t len)
+int RenderData::drawText(const char* text, Math::fvec2 pos, const Math::fvec4& col, int size, uint32_t flags, int32_t len, int32_t zLayer)
 {
+    auto& objects = zLayer > 0 ? this->objects2 : this->objects;
+    auto& commands = zLayer > 0 ? this->commands2 : this->commands;
+
     size_t numchars = len == -1 ? strlen(text) : len;
     size_t numcopy = numchars;
 
@@ -204,8 +207,11 @@ void RenderData::descissor()
     commands.push_back({Command::DESCISSOR, 0, 0, nullptr});
 }
 
-void RenderData::drawTexture(const fbox& rect, TexEntry* e, int state, int pixel_size, uint32_t flags)
+void RenderData::drawTexture(const fbox& rect, TexEntry* e, int state, int pixel_size, uint32_t flags, int32_t zLayer)
 {
+    auto& objects = zLayer > 0 ? this->objects2 : this->objects;
+    auto& commands = zLayer > 0 ? this->commands2 : this->commands;
+
     if (!e) return;
     int layer = 0;
     //#TODO: don't hard code numebrs
@@ -230,8 +236,11 @@ void RenderData::drawTexture(const fbox& rect, TexEntry* e, int state, int pixel
     commands.push_back({Command::QUAD, 1, flags, e});
 }
 
-void RenderData::drawQuad(const Math::fbox& rect, const Math::fvec4& col)
+void RenderData::drawQuad(const Math::fbox& rect, const Math::fvec4& col, int32_t zLayer)
 {
+    auto& objects = zLayer > 0 ? this->objects2 : this->objects;
+    auto& commands = zLayer > 0 ? this->commands2 : this->commands;
+
     ColQuad q = {
         .rect = fbox(rect.pos, rect.size),
         .col = col,
@@ -241,81 +250,87 @@ void RenderData::drawQuad(const Math::fbox& rect, const Math::fvec4& col)
     commands.push_back({Command::COLQUAD, 1, 0, nullptr});
 }
 
+
+
 void GLContext::renderFromRD(RenderData& data) {
-    auto& objects = data.objects;
-    auto& commands = data.commands;
-
     bindBuffers();
-    glNamedBufferSubData(m_ssb.objects.buf, 0, sizeof(RenderData::Object) * data.objects.size(), objects.data());
 
-    int count = 0;
-    for (auto& c : data.commands)
-    {
-        glNamedBufferSubData(m_ub.objIndex.buf, 0, sizeof(int), &count);
-        switch (c.type)
+    static auto renderBatch = [](GLContext& ctx, auto& objects, auto& commands) {
+        glNamedBufferSubData(ctx.m_ssb.objects.buf, 0, sizeof(RenderData::Object) * objects.size(), objects.data());
+
+        int count = 0;
+        for (auto& c : commands)
         {
-            case RenderData::Command::QUAD:
+            glNamedBufferSubData(ctx.m_ub.objIndex.buf, 0, sizeof(int), &count);
+            switch (c.type)
             {
-                glBindTextureUnit(m_ta.texture.bind, c.texentry->glID);
-                
-                if (c.flags & SLICE_9)
+                case RenderData::Command::QUAD:
                 {
-                    m_shaders.quad9slice.use();
-                    glUniform4f(m_shaders.quad9slice.slices,
-                                c.texentry->top, c.texentry->right, c.texentry->bottom, c.texentry->left);
-                    glDrawArraysInstanced(GL_TRIANGLES, 0, 6, c.number * 9);
+                    glBindTextureUnit(ctx.m_ta.texture.bind, c.texentry->glID);
+                    
+                    if (c.flags & SLICE_9)
+                    {
+                        ctx.m_shaders.quad9slice.use();
+                        glUniform4f(ctx.m_shaders.quad9slice.slices,
+                                    c.texentry->top, c.texentry->right, c.texentry->bottom, c.texentry->left);
+                        glDrawArraysInstanced(GL_TRIANGLES, 0, 6, c.number * 9);
+                    }
+                    else {
+                        ctx.m_shaders.quad.use();
+                        glDrawArraysInstanced(GL_TRIANGLES, 0, 6, c.number);
+                    }
+                    break;
                 }
-                else {
-                    m_shaders.quad.use();
+                case RenderData::Command::COLQUAD:
+                {
+                    ctx.m_shaders.colquad.use();
                     glDrawArraysInstanced(GL_TRIANGLES, 0, 6, c.number);
+                    break;
                 }
-                break;
-            }
-            case RenderData::Command::COLQUAD:
-            {
-                m_shaders.colquad.use();
-                glDrawArraysInstanced(GL_TRIANGLES, 0, 6, c.number);
-                break;
-            }
-            case RenderData::Command::CHARACTER:
-            {
-                m_shaders.text.use();
-                glDrawArraysInstanced(GL_TRIANGLES, 0, 6, c.number);
-                break;
-            }
-            case RenderData::Command::SCISSOR:
-            {
-                c.scissorBox.y = m_screen_size.y - c.scissorBox.y - c.scissorBox.height;
-
-                glEnable(GL_SCISSOR_TEST);
-                Math::ibox _b;
-                if (scissorStack.empty())
-                    _b = {0, 0, m_screen_size.x, m_screen_size.y};
-                else
-                    glGetIntegerv(GL_SCISSOR_BOX, (GLint*)&_b);
-
-                scissorStack.push(_b);
-                glScissor(c.scissorBox.x,
-                          c.scissorBox.y,
-                          c.scissorBox.width,
-                          c.scissorBox.height);
-                break;
-            }
-            case RenderData::Command::DESCISSOR:
-            {
-                //it shouldn't be empty, we always scissor before descissoring
-                if (!scissorStack.empty())
+                case RenderData::Command::CHARACTER:
                 {
-                    auto& _b = scissorStack.top();
-                    glScissor(_b.x, _b.y, _b.width, _b.height);
-                    scissorStack.pop();
+                    ctx.m_shaders.text.use();
+                    glDrawArraysInstanced(GL_TRIANGLES, 0, 6, c.number);
+                    break;
                 }
+                case RenderData::Command::SCISSOR:
+                {
+                    c.scissorBox.y = ctx.m_screen_size.y - c.scissorBox.y - c.scissorBox.height;
+
+                    glEnable(GL_SCISSOR_TEST);
+                    Math::ibox _b;
+                    if (scissorStack.empty())
+                        _b = {0, 0, ctx.m_screen_size.x, ctx.m_screen_size.y};
+                    else
+                        glGetIntegerv(GL_SCISSOR_BOX, (GLint*)&_b);
+
+                    scissorStack.push(_b);
+                    glScissor(c.scissorBox.x,
+                              c.scissorBox.y,
+                              c.scissorBox.width,
+                              c.scissorBox.height);
+                    break;
+                }
+                case RenderData::Command::DESCISSOR:
+                {
+                    //it shouldn't be empty, we always scissor before descissoring
+                    if (!scissorStack.empty())
+                    {
+                        auto& _b = scissorStack.top();
+                        glScissor(_b.x, _b.y, _b.width, _b.height);
+                        scissorStack.pop();
+                    }
+                }
+                default:
+                    break;
             }
-            default:
-                break;
+            count += c.number;
         }
-        count += c.number;
-    }
+    };
+
+    // Later we can do better Z ordering or something. Idk what the best approach will be without having to sort everything :thinking:
+    renderBatch(*this, data.objects, data.commands);
+    renderBatch(*this, data.objects2, data.commands2);
 }
 
 using namespace msdf_atlas;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -104,13 +104,21 @@ void GLContext::setScreenSize(int width, int height)
 
 #include "msdf-atlas-gen/msdf-atlas-gen.h"
 extern std::vector<msdf_atlas::GlyphGeometry> glyphs;
-int RenderData::drawText(const char* text, Math::fvec2 pos, const Math::fvec4& col, int size, uint32_t flags, float width)
+
+int32_t TexGui::computeTextWidth(const char* text, size_t numchars)
 {
-    size_t numchars = strlen(text);
+    uint32_t total = 0;
+    for (size_t i = 0; i < numchars; i++)
+    {
+        total += glyphs[m_char_map[text[i]]].getAdvance();
+    }
+    return total;
+}
+
+int RenderData::drawText(const char* text, Math::fvec2 pos, const Math::fvec4& col, int size, uint32_t flags, int32_t len)
+{
+    size_t numchars = len == -1 ? strlen(text) : len;
     size_t numcopy = numchars;
-
-    float currx = 0;
-
 
     const auto& a = glyphs[m_char_map['a']];
     if (flags & CENTER_Y)
@@ -122,14 +130,10 @@ int RenderData::drawText(const char* text, Math::fvec2 pos, const Math::fvec4& c
 
     if (flags & CENTER_X)
     {
-        for (int idx = 0; idx < numchars; idx++)
-        {
-            currx += glyphs[m_char_map[text[idx]]].getAdvance() * size;
-        }
-        pos.x -= currx / 2.0;
+        pos.x -= computeTextWidth(text, numchars) * size / 2.0;
     }
 
-    currx = pos.x;
+    float currx = pos.x;
 
     //const CharInfo& hyphen = m_char_map['-'];
     for (int idx = 0; idx < numchars; idx++)

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -105,9 +105,9 @@ void GLContext::setScreenSize(int width, int height)
 #include "msdf-atlas-gen/msdf-atlas-gen.h"
 extern std::vector<msdf_atlas::GlyphGeometry> glyphs;
 
-int32_t TexGui::computeTextWidth(const char* text, size_t numchars)
+float TexGui::computeTextWidth(const char* text, size_t numchars)
 {
-    uint32_t total = 0;
+    float total = 0;
     for (size_t i = 0; i < numchars; i++)
     {
         total += glyphs[m_char_map[text[i]]].getAdvance();
@@ -339,6 +339,7 @@ void GLContext::loadFont(const char* fontFilename)
             // In the last argument, you can specify a charset other than ASCII.
             // To load specific glyph indices, use loadGlyphs instead.
             fontGeometry.loadCharset(font, 1.0, Charset::ASCII);
+
             // Apply MSDF edge coloring. See edge-coloring.h for other coloring strategies.
             const double maxCornerAngle = 3.0;
             for (GlyphGeometry &glyph : glyphs)

--- a/src/texgui.cpp
+++ b/src/texgui.cpp
@@ -557,16 +557,24 @@ Container Container::ListItem(uint32_t* selected, uint32_t id)
         
         static TexEntry* tex = &m_tex_map[Defaults::ListItem::Texture];
 
-        auto& io = inputFrame;
+        auto state = STATE_NONE;
+        if (listItem->listItem.selected != nullptr)
+        {
+            auto& io = inputFrame;
 
-        bool hovered = listItem->parent->scissorBox.contains(io.cursorPos) 
-                    && bounds.contains(io.cursorPos);
-        auto state = hovered ? STATE_HOVER : STATE_NONE;
-        if (io.lmb == KEY_Release && hovered)
-            *(listItem->listItem.selected) = listItem->listItem.id;
+            bool hovered = listItem->parent->scissorBox.contains(io.cursorPos) 
+                        && bounds.contains(io.cursorPos);
+            state = hovered ? STATE_HOVER : STATE_NONE;
+            if (io.lmb == KEY_Release && hovered)
+                *(listItem->listItem.selected) = listItem->listItem.id;
 
-        if (*(listItem->listItem.selected) == listItem->listItem.id)
-            state = STATE_ACTIVE;
+            if (*(listItem->listItem.selected) == listItem->listItem.id)
+                state = STATE_ACTIVE;
+        }
+        else
+        {
+            state = listItem->listItem.id ? STATE_ACTIVE : STATE_NONE;
+        }
 
         listItem->rs->drawTexture(bounds, tex, state, _PX, SLICE_9);
 

--- a/src/texgui.cpp
+++ b/src/texgui.cpp
@@ -579,6 +579,28 @@ Container Container::ListItem(uint32_t* selected, uint32_t id)
     return listItem;
 }
 
+Container Container::Align(uint32_t flags, Math::fvec4 padding)
+{
+    static auto arrange = [](Container* align, fbox child)
+    {
+        auto f = align->align.flags;
+        if (f & ALIGN_LEFT) child.x = align->bounds.x;
+        if (f & ALIGN_RIGHT) child.x = align->bounds.x + align->bounds.width - child.width;
+
+        if (f & ALIGN_TOP) child.y = align->bounds.y;
+        if (f & ALIGN_BOTTOM) child.y = align->bounds.y + align->bounds.height - child.height;
+
+        if (f & ALIGN_CENTER_X) child.x = align->bounds.x + (align->bounds.width - child.width) / 2;
+        if (f & ALIGN_CENTER_Y) child.y = align->bounds.y + (align->bounds.height - child.height) / 2;
+
+        return child;
+    };
+    // Add padding to the contents
+    Container aligner = withBounds(fbox::pad(bounds, padding), arrange);
+    aligner.align.flags = flags;
+    return aligner;
+}
+
 // Arranges the cells of a grid by adding a new child box to it.
 Container Container::Grid()
 {

--- a/texgui.h
+++ b/texgui.h
@@ -442,6 +442,8 @@ public:
     void      TextInput(const char* name, std::string& buf);
     void      Image(TexEntry* texture);
 
+    Container Align(uint32_t flags = 0, Math::fvec4 padding = Math::fvec4(0,0,0,0));
+
     void      Clip();
     void      Unclip();
     // Similar to radio buttons - the id of the selected one is stored in the *selected pointer.
@@ -485,6 +487,11 @@ private:
             uint32_t* selected;
             uint32_t id;
         } listItem;
+
+        struct 
+        {
+            uint32_t flags;
+        } align;
     };
 
     void* scrollPanelState = nullptr;

--- a/texgui.h
+++ b/texgui.h
@@ -431,14 +431,15 @@ struct TextSegment
     {
         struct {
             const char* data;
-            int32_t tw; // Width of the text in pixels (not including whitespace)
+            float tw; // Width of the text (not including whitespace)
             int16_t len;
         } word;
 
         TexEntry* icon;
     };
 
-    int32_t width; // Width of the segment in pixels including whitespace
+    float width; // Width of the segment pre-scaling
+        // Pt for text, pixels for icons. Includes whitespace for text
 
     enum Type : uint8_t {
         WORD,        // Denotes text followed by whitespace
@@ -648,7 +649,7 @@ std::vector<TextSegment> cacheText(TextDecl text);
 // Caches text into a buffer. Asserts on failure
 void cacheText(TextDecl text, TextSegment* buffer, uint32_t capacity);
 
-int32_t computeTextWidth(const char* text, size_t numchars);
+float computeTextWidth(const char* text, size_t numchars);
 
 class RenderData
 {

--- a/texgui.h
+++ b/texgui.h
@@ -41,6 +41,8 @@ enum TexGui_flags : uint32_t
     ALIGN_BOTTOM = 0x4000,
 
     UNDERLINE = 0x8000,
+    LOCKED = 0x10000, // Window is immovable
+    HIDE_TITLE = 0x40000,
 };
 
 enum TexGui_state : uint8_t 
@@ -559,25 +561,25 @@ public:
 
     Container Grid();
         
+    void Row(Container* out, const float* widths, uint32_t n, float height, uint32_t flags = 0);
     template <uint32_t N>
     std::array<Container, N> Row(const float (&widths)[N], float height = 0, uint32_t flags = 0)
     {
         std::array<Container, N> out;
-        Row_Internal(&out[0], widths, N, height, flags);
+        Row(&out[0], widths, N, height, flags);
         return out;
     }
 
+    void Column(Container* out, const float* widths, uint32_t n, float height);
     template <uint32_t N>
     std::array<Container, N> Column(const float (&heights)[N], float width = 0)
     {
         std::array<Container, N> out;
-        Column_Internal(&out[0], heights, N, width);
+        Column(&out[0], heights, N, width);
         return out;
     }
 
 private:
-    void Row_Internal(Container* out, const float* widths, uint32_t n, float height, uint32_t flags);
-    void Column_Internal(Container* out, const float* widths, uint32_t n, float height);
     std::unordered_map<std::string, uint32_t>* buttonStates;
 
     Container* parent;

--- a/texgui.h
+++ b/texgui.h
@@ -554,6 +554,7 @@ public:
     void      Clip();
     void      Unclip();
     // Similar to radio buttons - the id of the selected one is stored in the *selected pointer.
+    // If you don't want them to be clickable - set selected to nullptr, and 0 or 1 for whether it is active in id
     Container ListItem(uint32_t* selected, uint32_t id);
 
     Container Grid();
@@ -648,7 +649,7 @@ namespace Tooltip {
     inline Math::fvec4 Padding(18, 12, 18, 12);
     inline float MaxWidth = 400;
 
-    inline Math::fvec2 UnderlineSize(2, 2);
+    inline Math::fvec2 UnderlineSize(0, 2);
 }
 
 namespace Settings {


### PR DESCRIPTION
- Simple align widget to add padding/alignment to anything
- Passing nullptr to List Items makes them unclickable and can just be used for display, e.g. an inventory hotbar
- Adds text block component. Caches text into words to allow for speedy wrapping calculation. Supports inline icons and tooltips