### PR TITLE
Added placeholders for text

### DIFF
--- a/src/texgui.cpp
+++ b/src/texgui.cpp
@@ -883,7 +883,7 @@ static void renderTooltip(Paragraph text, RenderData* rs)
 void Container::Text(Paragraph text, int32_t scale, TextDecl parameters)
 {
     float x = bounds.x;
-    float y = bounds.y + scale;
+    float y = bounds.y + scale / 2.0;
 
     writeText(text, scale, bounds, x, y, rs, false, 0, 0, parameters);
 }


### PR DESCRIPTION
Adds placeholders, which lets you insert dynamic text/icons into the middle of already cached text.

```c++
static auto cached = TexGui::cacheText({ "This part of the text is cached. But this part: ", TexGui::Placeholder(), " is dynamic." });
win.Text(cached, 20, {"my dynamic text"});
``` 